### PR TITLE
Fix for divide by zero bug

### DIFF
--- a/Benchmark/LineGraph.elm
+++ b/Benchmark/LineGraph.elm
@@ -22,7 +22,7 @@ graphResult w result =
         scaleResults : [Time] -> [Float]
         scaleResults times =
             let maxTime = maximum times
-                factor = dims.height / maxTime
+                factor = if maxTime == 0 then 0 else dims.height / maxTime
                 adjust y = (y * factor) + margin.bottom
             in  map adjust times
 


### PR DESCRIPTION
This bug was triggered when all benchmark results are 0
