### PR TITLE
Export Benchmark type

### DIFF
--- a/Benchmark.elm
+++ b/Benchmark.elm
@@ -3,6 +3,7 @@ module Benchmark
     , render
     , renderStatic
     , run
+    , Benchmark
     ) where
 {-| 
 Simple Benchmarking library


### PR DESCRIPTION
Allows you to run the `Example.elm` file, because types are no longer silently exported in Elm 0.13
