### PR TITLE
Update for Elm 0.14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 *~
-build/
-cache/
-*.elmi
-*.elmo
+/elm-stuff/
+/elm.js
 *.html
 node_modules/
-elm_dependencies/
 docs/

--- a/Benchmark.elm
+++ b/Benchmark.elm
@@ -18,9 +18,11 @@ Simple Benchmarking library
 
 import Benchmark.Types as T
 import Benchmark.Runner as R
+import List (..)
+import Graphics.Element (..)
 
 -- Bindings from other files for a cleaner export
-type Benchmark = T.Benchmark
+type alias Benchmark = T.Benchmark
 
 
 {-| Create a logic benchmark, running a function on many different inputs.
@@ -29,7 +31,7 @@ suite runs, you will see results for each input all labeled with the given name.
  
       logic "Date Parsing" parseDate [ "1/2/1990", "1 Feb 1990", "February 1, 1990" ]
 -}
-logic : String -> (input -> output) -> [input] -> Benchmark
+logic : String -> (input -> output) -> List input -> Benchmark
 logic name function inputs = 
   let noSetup f input = \_ -> let muted a = always () (f a)
                               in \_ -> muted input
@@ -51,7 +53,7 @@ see how well Elm's diffing engine does given the particular sequence you give it
 It may help to record a sequence of states directly from your project. Better to
 use real data instead of making it up!
 -}
-render : String -> (input -> Element) -> [input] -> Benchmark
+render : String -> (input -> Element) -> List input -> Benchmark
 render name function inputs =
   let noSetup f input = \_ _-> f input
   in  T.Render name <| map (noSetup function) inputs
@@ -76,5 +78,5 @@ completed, the screen will change to display them as a line graph
                  ]
     main = run benchmarks
 -}
-run : [Benchmark] -> Signal Element
+run : List Benchmark -> Signal Element
 run = R.run

--- a/Benchmark/DeferredSetup.elm
+++ b/Benchmark/DeferredSetup.elm
@@ -13,9 +13,11 @@ Benchmarks for more specific purposes where the basic ones will not suffice
 -}
 
 import Benchmark.Types as T
+import List (..)
+import Graphics.Element (..)
 
 -- Bindings from other files for a cleaner export
-type Benchmark = T.Benchmark
+type alias Benchmark = T.Benchmark
 
 
 {-| Run a staged benchmark. There is a setup phase and a timed phase.
@@ -37,7 +39,7 @@ to know how long it takes to visualize the audio frame. So you use a function to
 set things up for the visualizer (i.e., get the song and go to the specific
 frame).
 -}
-render : String -> (input -> Element) -> (seed -> input) -> [seed] -> Benchmark
+render : String -> (input -> Element) -> (seed -> input) -> List seed -> Benchmark
 render name function seedFunction seeds =
   let thunk f seededInputFunction = \_ -> let input = seededInputFunction ()
                                           in  \_ -> f input
@@ -62,7 +64,7 @@ It would be too much for many browsers to allocate dozens of 10000 element lists
 at the same time, so instead we allocate them when we need them. Garbage collection
 can reclaim the lists once the benchmark is done.
 -}
-logic : String -> (input -> output) -> (seed -> input) -> [seed] -> Benchmark
+logic : String -> (input -> output) -> (seed -> input) -> List seed -> Benchmark
 logic name function seedFunction seeds =
   let thunk f seededInputFunction = \_ -> let input = seededInputFunction ()
                                               muted x = always () (f x)
@@ -77,5 +79,5 @@ This will come in handy for the DS.logic benchmarks.
 
       trials = inputMap (\x -> [1..(1000 * x)]) [1..10]
 -}
-inputMap : (seed -> input) -> [seed] -> [() -> input]
+inputMap : (seed -> input) -> List seed -> List (() -> input)
 inputMap f xs = map (\x -> \() -> f x) xs

--- a/Benchmark/LineGraph.elm
+++ b/Benchmark/LineGraph.elm
@@ -1,8 +1,18 @@
 module Benchmark.LineGraph (showResults) where
 
 import Benchmark.Types (..)
+import Benchmark.Types
+import List (..)
+import Time (..)
+import Graphics.Collage (..)
+import Color (..)
+import Text (..)
+import Graphics.Element (..)
+import Graphics.Element
 
-type Coordinate = { x:Float, y:Float }
+type alias Coordinate = { x:Float, y:Float }
+
+type alias Result = Benchmark.Types.Result
 
 radius = 5
 h = 500
@@ -12,6 +22,8 @@ margin = { top = 75.0, left = 50.0, right = 75.0, bottom = 75.0 }
 
 types = ["Avenir, Futura, Times"]
 
+zip = map2 (,)
+
 graphResult : Int -> Result -> Element
 graphResult w result =
     let width  = toFloat w
@@ -19,7 +31,7 @@ graphResult w result =
                  , width  = width - margin.left - margin.right }
 
          {-| Scale the Y values to all fit within the graph area -}
-        scaleResults : [Time] -> [Float]
+        scaleResults : List Time -> List Float
         scaleResults times =
             let maxTime = maximum times
                 factor = if maxTime == 0 then 0 else dims.height / maxTime
@@ -27,7 +39,7 @@ graphResult w result =
             in  map adjust times
 
         {-| Equally space N points along the X axis line -}
-        spaceOut : Int -> [Float]
+        spaceOut : Int -> List Float
         spaceOut n =
             let base = [1..n]
                 adjust x = (toFloat x / toFloat n * dims.width) + margin.left
@@ -36,7 +48,7 @@ graphResult w result =
         {-| Reorient our points to use the Elm coordinate system 
             e.g., (0,0) -> (-width/2, -height/2)
         -}
-        fitPoints : [(Float, Float)] -> [(Float, Float)]
+        fitPoints : List (Float, Float) -> List (Float, Float)
         fitPoints points =
             let fit (x,y) = (x - (width / 2), y - (height / 2))
             in  map fit points
@@ -51,7 +63,7 @@ graphResult w result =
         centerOriginPoints = fitPoints centers
         datapoint ((x,y), time) = circle radius |> filled red |> move (x,y)
         datatime  ((x,y), time) =
-            show time |> toText |> typeface types
+            toString time |> fromString |> typeface types
                       |> centered |> toForm |> move (x + 15, y + 15)
                       |> rotate (degrees 30)
         -- Circles
@@ -65,9 +77,9 @@ graphResult w result =
             , segment (-width / 2 + margin.left, -height / 2 + margin.bottom) -- Y axis
                       (-width / 2 + margin.left,  height / 2 - margin.top)
                       |> traced (solid black)
-            , show result.name |> toText |> typeface types -- Test name
+            , toString result.name |> fromString |> typeface types -- Test name
                       |> centered |> toForm |> move (0, -(dims.height / 2) - 20)
-            , "milliseconds" |> toText |> typeface types |> centered |> toForm
+            , "milliseconds" |> fromString |> typeface types |> centered |> toForm
                       |> move (-width /2 + margin.left - 15 , 0) |> rotate (degrees 90)
             ]
         lines = path centerOriginPoints
@@ -80,7 +92,7 @@ graphResult w result =
     in collage w h forms
 
 
-showResults : Int -> [Result] -> Element
+showResults : Int -> List Result -> Element
 showResults width results = map (graphResult width) results
-                    |> intersperse (spacer width 10 |> color darkGrey)
+                    |> intersperse (spacer width 10 |> Graphics.Element.color darkGrey)
                     |> flow down

--- a/Benchmark/Runner.elm
+++ b/Benchmark/Runner.elm
@@ -3,20 +3,25 @@ module Benchmark.Runner
     ) where
 
 import Benchmark.Types (..)
+import Benchmark.Types
 import Benchmark.LineGraph (..)
 import Native.Runner
-import Either (..)
+import Result as Core
 import Window
+import List (..)
+import Signal
+import Graphics.Element (..)
 
+type alias Result = Benchmark.Types.Result
 
 numRepeats = 10
 
-duplicateEach : Int -> [a] -> [a]
+duplicateEach : Int -> List a -> List a
 duplicateEach n xs = foldr (++) [] <| map (repeat n) xs
 
 {-| Condenses every N elements in a list with `f`
 -}
-condenseEach : Int -> ([a] -> a) -> [a] -> [a]
+condenseEach : Int -> (List a -> a) -> List a -> List a
 condenseEach n f xs = case xs of
     [] -> []
     ys -> f (take n ys) :: condenseEach n f (drop n ys)
@@ -24,25 +29,25 @@ condenseEach n f xs = case xs of
 {-| Implicit assumption that we've got the same type of result.
 They should all have the same name and the same number of elements in .times
 -}
-averageResults : [Result] -> Result
+averageResults : List Result -> Result
 averageResults results =
     let n = length results
         times = map .times results
         numberOfData = length <| head times
-        summed = foldr (\t s -> zipWith (+) t s) (repeat numberOfData 0) times
+        summed = foldr (\t s -> map2 (+) t s) (repeat numberOfData 0) times
         avgs = map (\x -> toFloat (round ((x / toFloat n) * 10))/10 ) summed
     in { name=(head results).name, times=avgs }
 
 
-run : [Benchmark] -> Signal Element
+run : List Benchmark -> Signal Element
 run bms =
     let repeatedBms = duplicateEach numRepeats bms
-    in  lift2 display Window.width <| Native.Runner.runMany repeatedBms
+    in  Signal.map2 display Window.width <| Native.Runner.runMany repeatedBms
 
 
-display : Int -> Either Element [Result] -> Element
+display : Int -> Core.Result Element (List Result) -> Element
 display w elementString = case elementString of
-    Left element  -> element
-    Right results -> 
+    Core.Err element  -> element
+    Core.Ok results -> 
         let avgs = condenseEach numRepeats averageResults results
         in  showResults w avgs

--- a/Benchmark/Types.elm
+++ b/Benchmark/Types.elm
@@ -1,6 +1,9 @@
 module Benchmark.Types where
 
-type Result = { name:String, times:[Time] }
+import Time (..)
+import Graphics.Element (..)
 
-data Benchmark = Logic String [() -> () -> ()]
-               | Render String [() -> () -> Element]
+type alias Result = { name:String, times:List Time }
+
+type Benchmark = Logic String (List (() -> () -> ()))
+               | Render String (List (() -> () -> Element))

--- a/Example.elm
+++ b/Example.elm
@@ -1,6 +1,9 @@
 module Main where
 
 import Benchmark (..)
+import Graphics.Collage (..)
+import Color (..)
+import Graphics.Element (..)
 
 slowFib : Int -> Int
 slowFib n =  case n of
@@ -29,7 +32,7 @@ renderMark = render "Increase the radius of a circle" (circleWrapper red) [10..4
 staticMark : Benchmark
 staticMark = renderStatic "Blue Circle, radius 100" (circleWrapper blue 100)
 
-groupMark : [Benchmark]
+groupMark : List Benchmark
 groupMark = [ staticMark
             , renderMark
             , slowFibonacci

--- a/Native/Runner.js
+++ b/Native/Runner.js
@@ -26,7 +26,7 @@ Elm.Native.Runner.make = function(elm) {
     var Utils      = Elm.Native.Utils.make(elm);
     var ListUtils  = Elm.Native.List.make(elm);
     var Element    = Elm.Graphics.Element.make(elm);
-    var Renderer   = ElmRuntime.Render.Element();
+    var Renderer   = Elm.Native.Graphics.Element.make(elm);
     var Dimensions = Elm.Native.Window.make(elm).dimensions;
     function now() {
         // We get too many digits from accurate clocks. We only want one
@@ -99,7 +99,7 @@ Elm.Native.Runner.make = function(elm) {
                 bmIndex++;
                 if(bmIndex >= totalBenchmarks) {
                     console.log((now() - startTime));
-                    return { ctor : 'Right'
+                    return { ctor : 'Ok'
                            , _0   : ListUtils.fromArray(results)
                            }
                 }
@@ -117,7 +117,7 @@ Elm.Native.Runner.make = function(elm) {
                 setTimeout(function(){
                     elm.notify(deltas.id,{});
                 },0);
-                return { ctor : 'Left'
+                return { ctor : 'Err'
                        , _0   : emptyElem
                        }
             }
@@ -129,19 +129,19 @@ Elm.Native.Runner.make = function(elm) {
                 element = instrumentedElement(currentFunctions[index]);
             }
             index++;
-            return { ctor : 'Left'
+            return { ctor : 'Err'
                    , _0   : element
                    }
         }
 
         var bmBaseState;
         if(currentFunctionType === 'Logic') {
-            bmBaseState = { ctor : 'Left'
+            bmBaseState = { ctor : 'Err'
                           , _0   : emptyElem
                           }
         } else { // Render
             var elem = instrumentedElement(currentFunctions[index++]);
-            bmBaseState = { ctor : 'Left'
+            bmBaseState = { ctor : 'Err'
                           , _0   : elem
                           }
         }
@@ -176,7 +176,7 @@ Elm.Native.Runner.make = function(elm) {
                               , time: t1
                               };
             setTimeout(function() { elm.notify(deltas.id, deltaObject); }, 0);
-            return newRendering
+            return newRendering;
         }
 
         function benchUpdate(node, oldThunk, newThunk) {
@@ -190,6 +190,7 @@ Elm.Native.Runner.make = function(elm) {
                               , time: t1
                               };
             setTimeout(function() { elm.notify(deltas.id, deltaObject); }, 0);
+            return node;
         }
 
         function timeFunction(f) {

--- a/elm-core-benchmarks/Arrays.elm
+++ b/elm-core-benchmarks/Arrays.elm
@@ -3,6 +3,8 @@ module Main where
 import Benchmark (..)
 import Benchmark.DeferredSetup as DS
 import Array
+import List (..)
+import Graphics.Element (..)
 
 
 emptyBench =
@@ -72,7 +74,7 @@ toListBench =
 
 mapBench =
     let multiplier = 1000
-        toyFunction = id
+        toyFunction = identity
         trialData x = Array.repeat (multiplier * x) ()
         mapWrap array = Array.map toyFunction array
     in  DS.logic "map" mapWrap trialData [1..10]
@@ -96,7 +98,7 @@ foldrBench =
 
 
 
-benchmarks : [Benchmark]
+benchmarks : List Benchmark
 benchmarks = [ emptyBench
              , repeatBench
              , fromListBench

--- a/elm-core-benchmarks/Dicts.elm
+++ b/elm-core-benchmarks/Dicts.elm
@@ -3,7 +3,10 @@ module Main where
 import Benchmark (..)
 import Benchmark.DeferredSetup as DS
 import Dict as D
+import List (..)
+import Graphics.Element (..)
 
+zip = map2 (,)
 
 -- Convenience function for our set functions
 --setGenerator : ([number] -> [comparable]) -> number -> [() -> D.Dict comparable number]
@@ -184,13 +187,13 @@ fromListBench =
 mapBench =
     let multiplier = 1000
         listDictionary = dictList multiplier
-        mapWrap xs = D.map id xs
+        mapWrap xs = D.map (\_ -> identity) xs
     in DS.logic "map" mapWrap D.fromList listDictionary
 
 
 
 
-benchmarks : [Benchmark]
+benchmarks : List Benchmark
 benchmarks = [ insertBench
              , updateBench
              , removeBench

--- a/elm-core-benchmarks/Flows.elm
+++ b/elm-core-benchmarks/Flows.elm
@@ -1,18 +1,24 @@
 module Main where
 
 import Benchmark (..)
+import List (..)
+import Graphics.Element (..)
+import Graphics.Collage (..)
+import Color (..)
+import Text (markdown, asText)
 
+zip = map2 (,)
 
-imagePaths : [String]
-imagePaths = map (\x -> "images/" ++ show x ++ ".jpg") [1..12]
+imagePaths : List String
+imagePaths = map (\x -> "images/" ++ toString x ++ ".jpg") [1..12]
 
-directions : [Direction]
+directions : List Direction
 directions = [up, left, down, right, inward, outward]
 
 intToCircle : Int -> Form
 intToCircle n = filled red <| circle <| toFloat n
 
-sampleContent : [Element]
+sampleContent : List Element
 sampleContent = 
     let images = map (image 500 100) imagePaths
         markdowns = repeat 10 sampleMarkdown
@@ -23,7 +29,7 @@ sampleContent =
     in foldr (++) [] <| map flatten combine2
 
 sampleMarkdown : Element
-sampleMarkdown = [markdown|
+sampleMarkdown = asText """
 Notice again how text always lines up on 4-space indents (including
 that last line which continues item 3 above). Here's a link to [a
 website](http://foo.bar). Here's a link to a [local
@@ -49,7 +55,7 @@ oranges
   : Citrus!
 tomatoes
   : There's no "e" in tomatoe.
-|]
+"""
 
 
 
@@ -58,24 +64,24 @@ tomatoes
     We add and remove in every direction. This generates all those benchmarks
 -}
 
-elemsPerSet : [Int] -> [[Element]]
+elemsPerSet : List Int -> List (List Element)
 elemsPerSet xs = map (\x -> take x sampleContent) xs
 
-flowBenchmark: (String, [Int]) -> Direction -> Benchmark
-flowBenchmark (name,num) d = render (name ++ show d) (flow d) (elemsPerSet num)
+flowBenchmark: (String, List Int) -> Direction -> Benchmark
+flowBenchmark (name,num) d = render (name ++ toString d) (flow d) (elemsPerSet num)
 
-flowNames : [(String,[Int])]
+flowNames : List (String, List Int)
 flowNames = [ ("addToFlow (start at 1 end at 25 elements) -",[1..25])
             , ("removeFromFlow (start at 25 end at 1 element) -", reverse [1..25])
             ]
 
-flowStep : (String,[Int]) -> [Benchmark] -> [Benchmark]
+flowStep : (String, List Int) -> List Benchmark -> List Benchmark
 flowStep (name,num) xs = xs ++ (map (flowBenchmark (name,num)) directions)
 
-flowLayers : (String,[Int]) -> Benchmark
+flowLayers : (String, List Int) -> Benchmark
 flowLayers (name,num) = render (name ++ "-layer") layers (elemsPerSet num)
 
-flows : [Benchmark]
+flows : List Benchmark
 flows = (foldr flowStep [] flowNames) ++ map flowLayers flowNames
 
 
@@ -127,7 +133,7 @@ nestedFlowBench =
     in  render "sprialNestBench" sprialNest trials
 
 
-benchmarks : [Benchmark]
+benchmarks : List Benchmark
 benchmarks = flows ++
              [ addingToFlow
              , removingFromFlow

--- a/elm-core-benchmarks/Images.elm
+++ b/elm-core-benchmarks/Images.elm
@@ -1,9 +1,11 @@
 module Main where
 
 import Benchmark (..)
+import List (..)
+import Graphics.Element (..)
 
-imagePaths : [String]
-imagePaths = map (\x -> "images/" ++ show x ++ ".jpg") [1..12]
+imagePaths : List String
+imagePaths = map (\x -> "images/" ++ toString x ++ ".jpg") [1..12]
 
 
 imageDisplay : Benchmark
@@ -24,7 +26,7 @@ tiledImage20 = render "tiledImage20" (tiledImage 20 20) imagePaths
 tiledImage500 : Benchmark
 tiledImage500 = render "tiledImage500" (tiledImage 500 500) imagePaths
 
-benchmark : [Benchmark]
+benchmark : List Benchmark
 benchmark = [ imageDisplay
             , fittedImage500
             , fittedImage5

--- a/elm-core-benchmarks/Text.elm
+++ b/elm-core-benchmarks/Text.elm
@@ -1,6 +1,13 @@
 module Main where
 
 import Benchmark (..)
+import Text (..)
+import Text
+import List (..)
+import Graphics.Element (..)
+import Graphics.Element
+import Graphics.Collage (..)
+import Color (..)
 
 
 staticBenchs = [ renderStatic "Left" <| leftAligned copy
@@ -33,7 +40,7 @@ resizing = render "Markdown fitting into a smaller width" (\x -> width x md1)
     There should be an optimization to resolve only the last style
 -}
 stylespin : Benchmark
-stylespin = let flipflopper i text = case i `mod` 2 of 
+stylespin = let flipflopper i text = case i % 2 of
                                      0 -> monospace text
                                      1 -> typeface ["sans-serif"] text
                 spinner times = leftAligned <| foldr flipflopper copy [1..times]
@@ -57,23 +64,23 @@ changingTypesBetweenMarkdown =
     let display n = flow down [md1, n, md2]
         differentElems = [ asText "Text"
                          , collage 200 200 [circle 5 |> filled red]
-                         , spacer 500 50 |> color blue
+                         , spacer 500 50 |> Graphics.Element.color blue
                          ]
         trialData = foldr (\_ d -> differentElems ++ d) [] [1..5]
     in  [ render "Changing types of elements betweens static markdown" display trialData
-        , render "Changing types of elements no markdown" id trialData ]
+        , render "Changing types of elements no markdown" identity trialData ]
 
 duplicateMd =
-    let flipFlop n = case n `mod` 2 of
+    let flipFlop n = case n % 2 of
         0 -> md1
         1 -> md3
     in render "Switching between logically identical md blocks" flipFlop [1..20]
 
 changingMd =
     let trialData = foldr (\_ md -> md ++ [md1,md2,md4] ) [] [1..5]
-    in  render "Changing markdown blocks" id trialData
+    in  render "Changing markdown blocks" identity trialData
 
-benchmarks : [Benchmark]
+benchmarks : List Benchmark
 benchmarks = [ showmd
              , downsizing
              , resizing
@@ -97,7 +104,7 @@ main = run benchmarks
 -}
 
 copy : Text
-copy = toText "8-bit art party slow-carb authentic VHS next level, fixie Tumblr High Life put a bird on it ethical 90's swag scenester Kickstarter. Truffaut gastropub swag, drinking vinegar bitters Carles hashtag. Cray locavore jean shorts Tumblr drinking vinegar, trust fund Odd Future Helvetica PBR fingerstache iPhone food truck swag brunch tote bag. Food truck farm-to-table 90's fashion axe. Salvia synth bespoke, Shoreditch hoodie pour-over fixie typewriter leggings McSweeney's small batch. Forage DIY mustache, viral irony leggings salvia blog slow-carb. Pug fixie gentrify banh mi, Blue Bottle aesthetic direct trade food truck art party Tonx pour-over chillwave.
+copy = Text.fromString "8-bit art party slow-carb authentic VHS next level, fixie Tumblr High Life put a bird on it ethical 90's swag scenester Kickstarter. Truffaut gastropub swag, drinking vinegar bitters Carles hashtag. Cray locavore jean shorts Tumblr drinking vinegar, trust fund Odd Future Helvetica PBR fingerstache iPhone food truck swag brunch tote bag. Food truck farm-to-table 90's fashion axe. Salvia synth bespoke, Shoreditch hoodie pour-over fixie typewriter leggings McSweeney's small batch. Forage DIY mustache, viral irony leggings salvia blog slow-carb. Pug fixie gentrify banh mi, Blue Bottle aesthetic direct trade food truck art party Tonx pour-over chillwave.
 
 Pickled pour-over paleo Brooklyn fap seitan. Actually wolf seitan mixtape artisan. Bicycle rights Banksy wayfarers messenger bag roof party. Slow-carb letterpress pour-over Vice post-ironic, readymade chambray YOLO. Scenester try-hard whatever pickled, messenger bag before they sold out tofu meggings wolf biodiesel mumblecore. Swag Etsy tofu Blue Bottle, hella disrupt tattooed freegan kale chips cray pickled Neutra flannel. Cornhole butcher keytar disrupt gastropub Truffaut gentrify, asymmetrical roof party kitsch 3 wolf moon Neutra fashion axe.
 
@@ -106,7 +113,7 @@ Shoreditch wayfarers photo booth, bicycle rights farm-to-table asymmetrical pale
 Keffiyeh raw denim Williamsburg, iPhone flexitarian swag shabby chic semiotics banjo mumblecore sriracha pork belly. Meggings street art distillery banh mi mumblecore, selvage art party asymmetrical synth. Vice street art salvia mixtape Banksy tote bag, meh cray. Put a bird on it plaid Helvetica viral, mlkshk biodiesel banh mi artisan pour-over Austin Intelligentsia authentic chia aesthetic sartorial. Ennui twee bespoke Blue Bottle Godard. Irony gentrify actually, quinoa Tumblr locavore small batch four loko PBR&B cray raw denim Vice. Fingerstache cornhole meh keffiyeh, Kickstarter synth squid bespoke lo-fi viral ethnic McSweeney's."
 
 md1 : Element
-md1 = [markdown|
+md1 = asText """
 
 # Markdown Support
 
@@ -122,9 +129,9 @@ text elements. You can easily make:
 It all feels quite natural to type. For more information on Markdown,
 see [this site](http://daringfireball.net/projects/markdown/).
 
-|]
+"""
 
-md2 = [markdown|
+md2 = asText """
 
 # Anienis terebrata quoque Hector undae subit illo
 
@@ -143,10 +150,10 @@ Laedor **caelo annos sunt** timemus; mea non Cyllaron, videres! Pictis si tamen
 motaeque amantem **tuas haec compescuit**, mihi candida? Pallada hasta Themis
 pictis memor non homines potest, male nuribusque area tendentemque illo, quid?
 
-|]
+"""
 
 md3 : Element
-md3 = [markdown|
+md3 = asText """
 
 # Markdown Support
 
@@ -162,10 +169,10 @@ text elements. You can easily make:
 It all feels quite natural to type. For more information on Markdown,
 see [this site](http://daringfireball.net/projects/markdown/).
 
-|]
+"""
 
 md4 : Element
-md4 = [markdown|
+md4 = asText """
 
 # Markdown Support
 
@@ -195,7 +202,7 @@ text elements. You can easily make:
 It all feels quite natural to type. For more information on Markdown,
 see [this site](http://daringfireball.net/projects/markdown/).
 
-|]
+"""
 
 
 

--- a/elm-package.json
+++ b/elm-package.json
@@ -4,13 +4,15 @@
   "description" : "Benchmark your project! This library lets you test the speed of your logic, data structures, and rendering code.",
   "license" : "BSD 3-clause",
   "repository" : "https://github.com/michaelbjames/elm-benchmark.git",
+  "source-directories": [
+    "./"
+  ],
   "exposed-modules" :
     [ "Benchmark"
     , "Benchmark.DeferredSetup"
     ],
-  "native-modules" :
-    [ "Native.Runner"
-    ],
-  "elm-version" : "0.12.3",
-  "dependencies" : {}
+  "native-modules": true,
+  "dependencies" : {
+    "elm-lang/core": "1.1.0 <= v < 2.0.0"
+  }
 }


### PR DESCRIPTION
I got `Example.elm` to run and show results in Elm 0.14.  I've never used this package before, some I'm not able to tell if everything is working exactly right, but it looks pretty good.

The only non-trivial change was adding the `return node` line 193 in `Native/Runner.js`.  Without that there were a ton of console errors.  I didn't really understand how all that code works, but it seemed like the obvious thing to stick in there.

For the `elm-core-benchmarks`, markdown is no longer part of core, so I replaced the markdown blocks with `Text.asText`, but some of those benchmarks might not make sense any more.
